### PR TITLE
Explicitly require common lisp extensions.

### DIFF
--- a/colshift.el
+++ b/colshift.el
@@ -11,6 +11,7 @@
 ;;
 
 (require 'dash)
+(eval-when-compile (require 'cl))
 
 ;;; Code:
 


### PR DESCRIPTION
I had problem using colshift until I added this line. Emacs kept complaining about undefined symbols rotatef and concatenate.

My lisp-fu is pretty weak, so I don't really know if this is the correct way to solve it, or if you, for instance, should use cl-lib instead.
